### PR TITLE
Update Github actions as golangci-lint was failing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: 1.24
 
       - name: Run golangci-lint linter
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.0
+          version: v2.12.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
   go-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -17,4 +17,4 @@ jobs:
         run: go build -v ./...
 
       - name: Run Go tests
-        uses: robherley/go-test-action@v0
+        uses: robherley/go-test-action@v1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GoDoc](https://godoc.org/github.com/wainuiomata/echo-scs-session?status.png)](https://pkg.go.dev/github.com/wainuiomata/echo-scs-session?tab=doc)
 [![Go report card](https://goreportcard.com/badge/github.com/spazzymoto/echo-scs-session)](https://goreportcard.com/report/github.com/wainuiomata/echo-scs-session)
-[![Test coverage](http://gocover.io/_badge/github.com/spazzymoto/echo-scs-session)](https://gocover.io/github.com/wainuiomata/echo-scs-session)
+[![Test coverage](http://gocover.io/_badge/github.com/wainuiomata/echo-scs-session)](https://gocover.io/github.com/wainuiomata/echo-scs-session)
 
 Note this is a fork, credit goes to [spazzymoto](https://github.com/spazzymoto) for creating the original package [spazzymoto/echo-scs-session](https://github.com/spazzymoto/echo-scs-session).
 


### PR DESCRIPTION
It was failing because the version of node it was using (v20) was no longer supported.

Also update coverage link in the README to point to the correct repo, though it may be broken anyway.